### PR TITLE
cli: application instruments support

### DIFF
--- a/yoda-cli/package.json
+++ b/yoda-cli/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "commander": "^2.19.0",
-    "flora": "yodaos-project/node-flora#master",
+    "flora": "yodaos-project/node-flora#release/1.0.x",
     "glob": "^7.1.3",
     "lodash": "^4.17.11",
     "mustache": "^3.0.1",

--- a/yoda-cli/src/am.ts
+++ b/yoda-cli/src/am.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs'
 import { promisify } from 'util'
 import program from './program'
 import { printResult, getClient } from './util'
-import { ApplicationManager } from 'yoda-platform-lib'
+import { ApplicationManager, PackageManager } from 'yoda-platform-lib'
 import { pick } from 'lodash'
 
 const readFileAsync = promisify(fs.readFile)
@@ -76,6 +76,17 @@ program
     const am = new ApplicationManager(client)
     const result = await am.forceStop(packageName)
     printResult(result, 'force-stop')
+  })
+
+program
+  .command('logread <package-name>')
+  .description('logread convenience wrapper.')
+  .action(async (packageName, cmd) => {
+    const client = await getClient(DBusConnection, cmd.parent.serial)
+    const pm = new PackageManager(client)
+    const path = await pm.path(packageName)
+    var stream = await client.logread([ `^iotjs\\syoda-app\\s${path}` ])
+    stream.pipe(process.stdout)
   })
 
 export default program

--- a/yoda-cli/src/am.ts
+++ b/yoda-cli/src/am.ts
@@ -69,6 +69,17 @@ program
   })
 
 program
+  .command('instrument <package-name> <instruments-glob>')
+  .description('Launch app and run instruments.')
+  .action(async (packageName, instruments, cmd) => {
+    const client = await getClient(DBusConnection, cmd.parent.serial)
+    const am = new ApplicationManager(client)
+
+    const result = await am.launch(packageName, { mode: 'instrument', args: [ instruments ] })
+    printResult(result, 'instrument')
+  })
+
+program
   .command('force-stop <package-name>')
   .description('Force stop an app on device.')
   .action(async (packageName, cmd) => {

--- a/yoda-cli/yarn.lock
+++ b/yoda-cli/yarn.lock
@@ -558,9 +558,9 @@ find-up@^2.0.0:
   dependencies:
     locate-path "^2.0.0"
 
-flora@yodaos-project/node-flora#master:
+flora@yodaos-project/node-flora#release/1.0.x:
   version "0.1.0"
-  resolved "https://codeload.github.com/yodaos-project/node-flora/tar.gz/340fb5c765705423b3b55a718a1af0b3695704cd"
+  resolved "https://codeload.github.com/yodaos-project/node-flora/tar.gz/95d2c389332515eda789ac730ced8edf9df30902"
   dependencies:
     node-addon-api "^1.6.2"
 

--- a/yoda-platform-lib/src/application-manager.ts
+++ b/yoda-platform-lib/src/application-manager.ts
@@ -1,5 +1,5 @@
 // eslint-disable-next-line no-unused-vars
-import { PlatformClient } from './command'
+import { PlatformClient } from './platform-client'
 
 export interface IOpenUrlOptions {
   form?: 'cut' | 'scene'

--- a/yoda-platform-lib/src/application-manager.ts
+++ b/yoda-platform-lib/src/application-manager.ts
@@ -7,8 +7,10 @@ export interface IOpenUrlOptions {
 }
 
 export interface ILaunchOptions {
-  mode?: number
+  mode?: string
   stopBeforeLaunch?: boolean
+  args?: string[]
+  environs?: { [name: string]: string }
 }
 
 export class ApplicationManager {

--- a/yoda-platform-lib/src/index.ts
+++ b/yoda-platform-lib/src/index.ts
@@ -1,3 +1,3 @@
-export * from './command'
+export * from './platform-client'
 export * from './application-manager'
 export * from './package-manager'


### PR DESCRIPTION
Run application instruments with yoda-cli:

```sh
/awesome-app-home $ yoda-cli pm install .
/awesome-app-home $ yoda-cli am instrument <app-name> 'test/**/*.test.js'
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] documentation is changed or added
